### PR TITLE
`add-hook` to `server-done-hook` is redundant

### DIFF
--- a/emacs-everywhere.el
+++ b/emacs-everywhere.el
@@ -150,7 +150,6 @@ APP is an `emacs-everywhere-app' struct."
 
 ;;;###autoload
 (add-hook 'server-visit-hook #'emacs-everywhere-initialise)
-(add-hook 'server-done-hook #'emacs-everywhere-finish)
 
 (defvar emacs-everywhere-mode-initial-map
   (let ((keymap (make-sparse-keymap)))


### PR DESCRIPTION
By its API, we can assume that users will issue one of the commands, `C-c C-C`, `C-x 5 0` or `C-c C-k`, which all are bound to call `server-buffer-done`. Within `server-buffer-done`, `server-done-hook` being called. Thus, due to the redundant `add-hook`, we will end up call it once more.